### PR TITLE
Add LegacyFreeBusyStatus WorkingElsewhere

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/enumeration/misc/ExchangeVersion.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/enumeration/misc/ExchangeVersion.java
@@ -50,4 +50,10 @@ public enum ExchangeVersion {
    * Exchange2010_SP2.
    */
   Exchange2010_SP2,
+
+  // Microsoft Exchange 2013
+  /**
+   * Exchange2013.
+   */
+  Exchange2013,
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/enumeration/property/LegacyFreeBusyStatus.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/enumeration/property/LegacyFreeBusyStatus.java
@@ -56,7 +56,14 @@ public enum LegacyFreeBusyStatus {
   /**
    * The No data.
    */
-  NoData(4);
+  NoData(4),
+  
+  // The time slot associated with the appointment appears as Working Elsewhere.
+  /**
+   * The WorkingElsewhere.
+   */
+  WorkingElsewhere(5);
+  
 
   /**
    * The busy status.

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/PropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/PropertyDefinition.java
@@ -226,4 +226,11 @@ public abstract class PropertyDefinition extends
   @Override public String getPrintableName() {
     return this.getName();
   }
+  
+  /**
+   * For a better debugging if you look at a PropertyBag.  
+   */
+  @Override	public String toString() {
+    return this.xmlElementName;
+  }
 }


### PR DESCRIPTION
Add the LegacyFreeBusyStatus WorkingElsewhere of an appointment.
This value was introduces by Exchange2013.
The enum element Exchange2013 is also added in ExchangeVersion.